### PR TITLE
Replace Oj JSON for MultiJson

### DIFF
--- a/influx.rb
+++ b/influx.rb
@@ -21,7 +21,7 @@ module Sensu::Extension
 
     def run(event)
       begin
-        event = Oj.load(event)
+        event = MultiJson.load(event)
         host = event[:client][:name]
         series = event[:check][:name]
         timestamp = event[:check][:issued]


### PR DESCRIPTION
`Oj JSON` was deprecated in `Sensu@0.13.0`.

[Sensu Changelog](https://github.com/sensu/sensu/blob/v0.13.0/CHANGELOG.md)
