### PR TITLE
Use name from definition block

### DIFF
--- a/influxdb.rb
+++ b/influxdb.rb
@@ -6,7 +6,7 @@ require "json"
 module Sensu::Extension
   class InfluxDB < Handler
     def name
-      "InfluxDB"
+      definition[:name]
     end
 
     def definition


### PR DESCRIPTION
Fixes handler calling problems related to to naming inconsistency.
