### PR TITLE
Delete stop method

### DIFF
--- a/influxdb.rb
+++ b/influxdb.rb
@@ -61,10 +61,6 @@ module Sensu::Extension
       end
     end
 
-    def stop
-      yield("InfluxDB: Handler finished", 0)
-    end
-
     private
       def parse_event(event_data)
         begin


### PR DESCRIPTION
There is no need to yield a block when Sensu stops anymore.
