### PR TITLE
* adding yield at end of run block, to allow sensu-server shutdown

### DIFF
--- a/influxdb.rb
+++ b/influxdb.rb
@@ -24,6 +24,10 @@ module Sensu::Extension
       # NOTE: Making sure we do not get any data from the Main
     end
 
+    def numeric?(value)
+      true if Float(value) rescue false
+    end
+
     def run(event_data)
       data = parse_event(event_data)
       values = Array.new()
@@ -40,8 +44,13 @@ module Sensu::Extension
         end
 
         metrics.push(key)
-        # TODO: Try and sanitise the time
-        values.push(value)
+       
+        # cast to numeric for values that look numeric	
+	if numeric?(value)
+          value = Float(value)
+	end
+
+	values.push(value)
       end
 
       body = [{


### PR DESCRIPTION
Without adding this yield, I could never shutdown sensu-server using `/etc/init.d/sensu-server restart`

In the logs, you'd see this, where _handlers_in_progress_count_ would be a higher value, depending on how many influxdb handler calls were made.   

This patch allows me to restart OK.

```
{"timestamp":"2014-12-26T17:41:42.569722+0000","level":"warn","message":"received signal","signal":"TERM"}
{"timestamp":"2014-12-26T17:41:42.570002+0000","level":"warn","message":"stopping"}
{"timestamp":"2014-12-26T17:41:42.570101+0000","level":"warn","message":"unsubscribing from keepalive and result queues"}
{"timestamp":"2014-12-26T17:41:42.570391+0000","level":"warn","message":"resigning as master"}
{"timestamp":"2014-12-26T17:41:42.570501+0000","level":"info","message":"completing handlers in progress","handlers_in_progress_count":2}
```
