### PR TITLE
Optionally read database target from check metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ Just drop the file in `/etc/sensu/extensions` and add it to your `metrics` confi
     "metrics": {
       "type": "set",
       "handlers": [ "debug", "influxdb"]
+      }
+    }
+  }
+}
+```
+In the check config, an optional `influxdb` section can be added, containing a `database` option. If specified, this overrides the default `database` option in the handler config. This allows events to be written to different influxdb databases on a check-by-check basis.
+
+## Example check config (`/etc/sensu/conf.d/check_foo.json`)
+
+```json
+{
+  "checks": {
+    "foo": {
+      "command": "check-foo",
+      "handlers": ["metrics"],
+      "influxdb": {
+        "database": "name"
+      }
     }
   }
 }

--- a/influxdb.rb
+++ b/influxdb.rb
@@ -51,8 +51,9 @@ module Sensu::Extension
       }]
 
       settings = parse_settings()
+      database = data["influxdb"]["database"] || settings["database"]
 
-      EventMachine::HttpRequest.new("http://#{ settings["host"] }:#{ settings["port"] }/db/#{ settings["database"] }/series?u=#{ settings["user"] }&p=#{ settings["password"] }").post :head => { "content-type" => "application/x-www-form-urlencoded" }, :body => body.to_json
+      EventMachine::HttpRequest.new("http://#{ settings["host"] }:#{ settings["port"] }/db/#{ database }/series?u=#{ settings["user"] }&p=#{ settings["password"] }").post :head => { "content-type" => "application/x-www-form-urlencoded" }, :body => body.to_json
     end
 
     private
@@ -60,6 +61,7 @@ module Sensu::Extension
         begin
           event = JSON.parse(event_data)
           data = {
+            "database" => event["check"]["influxdb"]["database"],
             "duration" => event["check"]["duration"],
             "host" => event["client"]["name"],
             "output" => event["check"]["output"],


### PR DESCRIPTION
Hi,

Firstly, apologies in advance if you're not accepting PRs on this project - but having looked at the 17 forks of lusis' original project, yours seems to be the most stable and widely-used/contributed to...

If you are, then please consider this PR, which allows you to set the influx database to sent the metrics data on to by specifying a database in the check definition using the 'influxdb' key.  If you don't set one, the default 'database' key in the extension config is used instead.

Let me know what you think...

thanks!