### PR TITLE
Fix nil value for name attribute

### DIFF
--- a/influxdb.rb
+++ b/influxdb.rb
@@ -36,7 +36,7 @@ module Sensu::Extension
         end
 
         body = [{
-          "name" => key.gsub!('-',''),
+          "name" => key.gsub('-',''),
           "columns" => ["time", "value"],
           "points" => [[time.to_f, value.to_f]]
         }]


### PR DESCRIPTION
`String.gsub!` returns `nil` as it modifies the string directly. `String.gsub` returns a new string.