### PR TITLE
adding yield and stop function for safe-stop

### DIFF
--- a/influxdb.rb
+++ b/influxdb.rb
@@ -52,6 +52,11 @@ module Sensu::Extension
         EventMachine::HttpRequest.new("#{ protocol }://#{ settings["host"] }:#{ settings["port"] }/db/#{ database }/series?u=#{ settings["user"] }&p=#{ settings["password"] }").post :head => { "content-type" => "application/x-www-form-urlencoded" }, :body => body.to_json
 
       end
+      yield("", 0)
+    end
+
+    def stop
+      yield
     end
 
     private


### PR DESCRIPTION
This should make Sensu stop working as intended (no more kill -9 :smiley: ) !

code grabbed from Sensu docs draft : 
https://github.com/rmc3/sensu-docs/blob/04b76b3baf801843784386eef7d7e90b88fb8e91/source/docs/0.16/extensions.md