### PR TITLE
Don't yield in stop

### DIFF
--- a/influxdb.rb
+++ b/influxdb.rb
@@ -57,7 +57,7 @@ module Sensu::Extension
     end
 
     def stop
-      yield
+      true
     end
 
     private


### PR DESCRIPTION
This resolves this error:
```
/etc/sensu/extensions/influxdb.rb:60:in `stop': no block given (yield) (LocalJumpError)
        from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-extension-1.1.2/lib/sensu/extension.rb:24:in `block in initialize'
        from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/eventmachine-1.0.3/lib/eventmachine.rb:190:in `call'
        from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/eventmachine-1.0.3/lib/eventmachine.rb:190:in `run'
        from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-0.20.3/lib/sensu/server/process.rb:23:in `run'
        from /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-0.20.3/bin/sensu-server:10:in `<top (required)>'
        from /opt/sensu/bin/sensu-server:23:in `load'
        from /opt/sensu/bin/sensu-server:23:in `<main>'
```