### PR TITLE
use raw host name + add time precision option

### DIFF
--- a/influxdb.rb
+++ b/influxdb.rb
@@ -38,7 +38,7 @@ module Sensu::Extension
         end
 
         body = [{
-          "name" => key.gsub('-',''),
+          "name" => key,
           "columns" => ["time", "value"],
           "points" => [[time.to_f, value.to_f]]
         }]
@@ -50,7 +50,7 @@ module Sensu::Extension
           protocol = "https"
         end
         
-        EventMachine::HttpRequest.new("#{ protocol }://#{ conf["host"] }:#{ conf["port"] }/db/#{ database }/series?u=#{ conf["user"] }&p=#{ conf["password"] }").post :head => { "content-type" => "application/x-www-form-urlencoded" }, :body => body.to_json
+        EventMachine::HttpRequest.new("#{ protocol }://#{ conf["host"] }:#{ conf["port"] }/db/#{ database }/series?time_precision=#{ data["time_precision"] }&u=#{ conf["user"] }&p=#{ conf["password"] }").post :head => { "content-type" => "application/x-www-form-urlencoded" }, :body => body.to_json
 
       end
       yield("", 0)
@@ -70,7 +70,8 @@ module Sensu::Extension
             "host" => event["client"]["name"],
             "output" => event["check"]["output"],
             "series" => event["check"]["name"],
-            "timestamp" => event["check"]["issued"]
+            "timestamp" => event["check"]["issued"],
+            "time_precision" => event["check"].fetch("time_precision", "s") # n, u, ms, s, m, and h (default community plugins use standard epoch date)
           }
         rescue => e
           puts " Failed to parse event data: #{e} "


### PR DESCRIPTION
_This PR is based on old & outdated PR #21._

2 things : 
* Change Body ```"name" => key.gsub!('-','')``` to ```"name" => key```
    * AFAIK there's no technical limit that prevent us to use ```-``` in metric name.
* add ```time_precision``` in influx url option.
    * Default time precision is still ```s``` but we can now specify any precision that is supported by Influx rest API. (see : [influxdb.go#L629](https://github.com/influxdb/influxdb/blob/72f6f7d268407ed128502618e18db3063f391d8e/client/influxdb.go#L629-L652) )
    * see also : https://influxdb.com/docs/v0.9/concepts/glossary.html#timestamp
    * time_precision option can now be specify inside the check's JSON output : 


_a check with a modified metrics-load script that use ms epoch timestamps_ 
```json
{
  "checks": {
    "metric-load": {
      "interval": 10,
      "type": "metric",
      "command": "metrics-load-ms.rb",
      "time_precision": "ms",
      "subscribers": [
        "all"
      ],
      "handlers": [
        "influx"
      ]
    }
  }
}
```

_Result_ : 
```
POST /db/sensu.metrics/series?time_precision=ms&u=*****&p=***** HTTP/1.1
Content-Type: application/x-www-form-urlencoded
Connection: close
Host: dev.metrics.local:8086
User-Agent: EventMachine HttpClient
Content-Length: 90

[{"name":"test.load_avg.one","columns":["time","value"],"points":[[1443099053000.0,2.0]]}]
```

_With the real community plugin (that output with epoch in seconds)_ : 
```
POST /db/sensu.metrics/series?time_precision=s&u=*****&p=***** HTTP/1.1
Content-Type: application/x-www-form-urlencoded
Connection: close
Host: dev.metrics.local:8086
User-Agent: EventMachine HttpClient
Content-Length: 87

[{"name":"test.load_avg.one","columns":["time","value"],"points":[[1443097834.0,0.0]]}]
```